### PR TITLE
Avoid error with inversion of a singular matrix

### DIFF
--- a/nsclean/NSClean.py
+++ b/nsclean/NSClean.py
@@ -131,9 +131,11 @@ class NSClean:
             
             # For debugging
             # if y != 1024: continue
-            
+
             # Get data and weights for this line
             d = D[y][self.M[y]] # Data
+            if (len(d) == 0):
+                continue
             p = np.diag(self.P[y][self.M[y]]) # Weights
             
             # Fill statistical outliers with line median. We know that the rolling
@@ -158,7 +160,11 @@ class NSClean:
             # $A^+ = (A^H A)^{-1} A^H$
             A = np.matmul(p, B)
             AH = np.conjugate(A.transpose()) # Hermitian transpose of A
-            pinv_PB = np.matmul(np.linalg.inv(np.matmul(AH, A)), AH)
+            try:
+                pinv_PB = np.matmul(np.linalg.inv(np.matmul(AH, A)), AH)
+            except np.linalg.LinAlgError:
+                print("WARNING: Singular matrix. Using pseudo-inverse.")
+                pinv_PB = np.matmul(np.linalg.pinv(np.matmul(AH, A)), AH)
             
             # Solve for the Fourier transform of this line's background samples.
             # The way that we have done it, this multiplies the input data by the 

--- a/nsclean/NSClean.py
+++ b/nsclean/NSClean.py
@@ -131,7 +131,6 @@ class NSClean:
             
             # For debugging
             # if y != 1024: continue
-
             # Get data and weights for this line
             d = D[y][self.M[y]] # Data
             if (len(d) == 0):
@@ -163,7 +162,6 @@ class NSClean:
             try:
                 pinv_PB = np.matmul(np.linalg.inv(np.matmul(AH, A)), AH)
             except np.linalg.LinAlgError:
-                print("WARNING: Singular matrix. Using pseudo-inverse.")
                 pinv_PB = np.matmul(np.linalg.pinv(np.matmul(AH, A)), AH)
             
             # Solve for the Fourier transform of this line's background samples.

--- a/nsclean/NSClean.py
+++ b/nsclean/NSClean.py
@@ -131,6 +131,7 @@ class NSClean:
             
             # For debugging
             # if y != 1024: continue
+
             # Get data and weights for this line
             d = D[y][self.M[y]] # Data
             if (len(d) == 0):


### PR DESCRIPTION
This PR:

- avoids error when encountering a singular matrix inversion by using Moore-Pensore pseudo-inversion,
- avoids error when the data slice taken in the `NSClean.fit()` has length 0.